### PR TITLE
スクリプト場所以下VRMConvertにBlender環境を設定

### DIFF
--- a/_convert.bat
+++ b/_convert.bat
@@ -3,6 +3,8 @@ chcp 65001
 setlocal
 :first
 
+set BLENDER_USER_CONFIG=%~dp0%\VRMConvert
+set BLENDER_USER_SCRIPTS=%~dp0%\VRMConvert
 for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).DisplayVersion"`) do set version=%%A
 for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%

--- a/_convert_manual.bat
+++ b/_convert_manual.bat
@@ -2,6 +2,8 @@
 chcp 65001
 setlocal
 
+set BLENDER_USER_CONFIG=%~dp0%\VRMConvert
+set BLENDER_USER_SCRIPTS=%~dp0%\VRMConvert
 for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).DisplayVersion"`) do set version=%%A
 for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%

--- a/_license-check.bat
+++ b/_license-check.bat
@@ -3,6 +3,8 @@ chcp 65001
 setlocal
 :first
 
+set BLENDER_USER_CONFIG=%~dp0%\VRMConvert
+set BLENDER_USER_SCRIPTS=%~dp0%\VRMConvert
 for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).DisplayVersion"`) do set version=%%A
 for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%


### PR DESCRIPTION
スクリプトの場所直下、VRMConvertにBlenderの環境を構築します。これにより、ユーザー環境の影響を受けず、また与えずに実行することができるようになります。

Resolves #7