### PR TITLE
Blenderインストール先の手動指定

### DIFF
--- a/_convert.bat
+++ b/_convert.bat
@@ -9,6 +9,8 @@ for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\
 for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%
 
+if defined BLENDER_LOCATION_OVERRIDE (set blender=%BLENDER_LOCATION_OVERRIDE%)
+
 for /f "usebackq delims=" %%A in (`curl --version`) do set curlresult=%%A
 for /f "usebackq delims=" %%A in (`ver`) do set windowsversion=%%A
 

--- a/_convert_manual.bat
+++ b/_convert_manual.bat
@@ -8,6 +8,8 @@ for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\
 for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%
 
+if defined BLENDER_LOCATION_OVERRIDE (set blender=%BLENDER_LOCATION_OVERRIDE%)
+
 for /f "usebackq delims=" %%A in (`curl --version`) do set curlresult=%%A
 for /f "usebackq delims=" %%A in (`ver`) do set windowsversion=%%A
 

--- a/_license-check.bat
+++ b/_license-check.bat
@@ -9,6 +9,8 @@ for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\
 for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%
 
+if defined BLENDER_LOCATION_OVERRIDE (set blender=%BLENDER_LOCATION_OVERRIDE%)
+
 timeout 3
 
 echo "VRMアドオンの最新版を取得中…"


### PR DESCRIPTION
#8 の要項を満たすものかは分かりませんが、個人的に必要（ZIPファイルでダウンロードしたものを使用している環境がある）だったので実装しました。

BLENDER_LOCATION_OVERRIDEの環境変数が指定されている場合はこちらの値を持ってくるようにしています。