### PR TITLE
[codex] Support Blender 5 conversion scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-VRM_Addon_for_Blender-release.zip
 VRMConvert/
 *.vrm
 *.glb
+scripts/VRM_Addon_for_Blender-release.zip
+scripts/VRM_Addon_for_Blender-Extension-release.zip

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Blenderに [VRM_Addon_for_Blender](https://vrm-addon-for-blender.info/) (iCyP様
 ## 前提ツール
 
 Blenderだけ入れてればOK。  
-Blenderはversion3.0以降でのみ動作します(厳密には2.93 LTSまで動作確認していますが、今から導入する場合は3系をお勧めします)  
-もしまだ入れていない方はこちらからどうぞ: [Blender公式サイト](https://www.blender.org/download/release/Blender3.4/blender-3.4.1-windows-x64.msi/)
+Blenderはversion4.2以降でのみ動作します。4.2 LTS以降のBlenderを利用してください。
+もしまだ入れていない方はこちらからどうぞ: [Blender公式サイト](https://www.blender.org/download/)
 
 ## ダウンロード
 

--- a/_convert.bat
+++ b/_convert.bat
@@ -26,7 +26,6 @@ for /f "usebackq delims=" %%A in (`curl --version`) do set curlresult=%%A
 for /f "usebackq delims=" %%A in (`ver`) do set windowsversion=%%A
 
 rem Blender 4.2以上のみ対応し、Extensionシステムを使用
-set use_extension=false
 set supported_blender=false
 for /f "tokens=1,2 delims=." %%a in ("%version%") do (
     set major=%%a
@@ -34,32 +33,22 @@ for /f "tokens=1,2 delims=." %%a in ("%version%") do (
 )
 if defined major (
     if !major! GEQ 5 (
-        set use_extension=true
         set supported_blender=true
     )
     if !major! EQU 4 if defined minor if !minor! GEQ 2 (
-        set use_extension=true
         set supported_blender=true
     )
 )
-if exist "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" (set blender-addon=true) else (set blender-addon=false)
-
 echo.
 echo ===Enviroment Checker===
 echo BlenderVersion: %version%
 echo BlenderInstallLocation: %blender%
 echo CurlResult: %curlresult%
 echo WindowsVersion: %windowsversion%
-echo BlenderAddonInstalled: !blender-addon!
-echo UseExtension: !use_extension!
 
 timeout 3
 
-if "%blender%" == "" (
-    echo "Blenderが検出できませんでした。インストールしているか、BLENDER_LOCATION_OVERRIDE環境変数で場所を指定しているか確認してください。"
-    echo "Blender公式サイト: https://www.blender.org/download/"
-    goto error-blender
-)
+if "%blender%" == "" goto error-blender
 if "!supported_blender!" == "false" goto error-blender-version
 
 echo "Extension版VRMアドオンの最新版を取得中…"
@@ -76,10 +65,8 @@ for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "Join-Path %bl
 set blender="%blender%"
 
 rem Extension mode: pre-install extension via Blender CLI
-if "!use_extension!" == "true" (
-    echo "VRM Extensionをインストール中…"
-    %blender% --command extension install-file "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" -r user_default -e
-)
+echo "VRM Extensionをインストール中…"
+%blender% --command extension install-file "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" -r user_default -e
 
 :cycle
 
@@ -97,7 +84,7 @@ echo ===Convert Files Checker===
 echo BLENDER = %BLENDER%
 echo VRM = %VRM%
 echo OUTPUT = %OUTPUT%
-echo ADDONFILE = Extension mode
+echo EXTENSIONFILE = "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip"
 echo.
 echo.
 
@@ -194,6 +181,7 @@ echo "Blenderを標準のインストール位置から変更しているか、�
 echo "標準のインストール位置から変更している場合はblender.exeまでのパスが通っているか確認してください(フォルダ名まで検索した後は手動で処理しています)"
 echo "Blenderのインストール場所を手動で指定する場合は BLENDER_LOCATION_OVERRIDE 環境変数にblender.exeが入っているディレクトリを指定してください"
 echo "インストールしていない場合はBlender4.2以上をインストールお願いします"
+echo "Blender公式サイト: https://www.blender.org/download/"
 echo "何かキーをクリックすると終了します"
 pause
 goto end

--- a/_convert.bat
+++ b/_convert.bat
@@ -5,8 +5,8 @@ setlocal enabledelayedexpansion
 
 set BLENDER_USER_CONFIG=%~dp0%\scripts\VRMConvert
 set BLENDER_USER_SCRIPTS=%~dp0%\scripts\VRMConvert
-for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).DisplayVersion"`) do set version=%%A
-for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).DisplayVersion"`) do set version=%%A
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%
 
 if defined BLENDER_LOCATION_OVERRIDE (set blender=%BLENDER_LOCATION_OVERRIDE%)
@@ -52,7 +52,7 @@ timeout 3
 
 if "!use_extension!" == "true" (
     echo "Extension版VRMアドオンの最新版を取得中…"
-    for /f "usebackq delims=" %%A in (`powershell -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM-Addon-for-Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
+    for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM-Addon-for-Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
     if defined extension_url (
         curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
     ) else (
@@ -72,7 +72,7 @@ goto first
 )
 set blender='%blender%'
 
-for /f "usebackq delims=" %%A in (`powershell -command "Join-Path %blender% blender.exe"`) do set blender=%%A
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "Join-Path %blender% blender.exe"`) do set blender=%%A
 set blender="%blender%"
 
 rem Extension mode: pre-install extension via Blender CLI
@@ -84,7 +84,13 @@ if "!use_extension!" == "true" (
 :cycle
 
 set VRM=%1
-set OUTPUT="%~1-converted.glb"
+set VRM_PATH=%~1
+if "%VRM_PATH:~0,2%" == "~/" set VRM_PATH=%USERPROFILE%\%VRM_PATH:~2%
+if "%VRM_PATH:~0,2%" == "~\" set VRM_PATH=%USERPROFILE%\%VRM_PATH:~2%
+set VRM_PATH=%VRM_PATH:/=\%
+if not "%VRM_PATH%" == "" set VRM="%VRM_PATH%"
+set OUTPUT="%VRM_PATH%-converted.glb"
+for %%F in ("%VRM_PATH%") do set VRM_DIR=%%~dpF
 
 echo.
 echo ===Convert Files Checker===
@@ -152,7 +158,7 @@ echo.
 echo "Resoniteにインポートするファイル・フォルダは以下の二つです"
 echo.
 echo %OUTPUT%
-echo %~dp1% "に生成された.texturesフォルダ"
+echo %VRM_DIR% "に生成された.texturesフォルダ"
 echo.
 echo.
 echo "フォルダの方はテクスチャが正常に紐つかない場合に使用していただき"

--- a/_convert.bat
+++ b/_convert.bat
@@ -30,7 +30,7 @@ for /f "tokens=1,2 delims=." %%a in ("%version%") do (
 )
 if defined major (
     if !major! GEQ 5 set use_extension=true
-    if !major! EQU 4 if !minor! GEQ 2 set use_extension=true
+    if !major! EQU 4 if defined minor if !minor! GEQ 2 set use_extension=true
 )
 
 if "!use_extension!" == "true" (
@@ -52,7 +52,7 @@ timeout 3
 
 if "!use_extension!" == "true" (
     echo "Extension版VRMアドオンの最新版を取得中…"
-    for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM-Addon-for-Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
+    for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM_Addon_for_Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
     if defined extension_url (
         curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
     ) else (

--- a/_convert.bat
+++ b/_convert.bat
@@ -9,7 +9,7 @@ for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProp
 for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%
 
-if defined BLENDER_LOCATION_OVERRIDE (set blender=%BLENDER_LOCATION_OVERRIDE%)
+if defined BLENDER_LOCATION_OVERRIDE (set "blender=%BLENDER_LOCATION_OVERRIDE%")
 
 rem Fallback: レジストリからバージョンを取得できない場合(Steam版等)、blender.exeから直接取得
 if "%version%" == "" if defined blender (

--- a/_convert.bat
+++ b/_convert.bat
@@ -11,11 +11,33 @@ set blender=%blender:"=%
 
 if defined BLENDER_LOCATION_OVERRIDE (set blender=%BLENDER_LOCATION_OVERRIDE%)
 
+rem Fallback: レジストリからバージョンを取得できない場合(Steam版等)、blender.exeから直接取得
+if "%version%" == "" if defined blender (
+    echo "レジストリからBlenderバージョンを検出できませんでした。blender.exeから直接取得します…"
+    for /f "tokens=2 delims= " %%A in ('"%blender%\blender.exe" --version 2^>nul') do (
+        if not defined version set version=%%A
+    )
+)
+
 for /f "usebackq delims=" %%A in (`curl --version`) do set curlresult=%%A
 for /f "usebackq delims=" %%A in (`ver`) do set windowsversion=%%A
 
-if exist "%~dp0scripts\VRM_Addon_for_Blender-release.zip" set blender-addon=true
-if not exist "%~dp0scripts\VRM_Addon_for_Blender-release.zip" set blender-addon=false
+rem Blender 4.2以上ではExtensionシステムを使用
+set use_extension=false
+for /f "tokens=1,2 delims=." %%a in ("%version%") do (
+    set major=%%a
+    set minor=%%b
+)
+if defined major (
+    if !major! GEQ 5 set use_extension=true
+    if !major! EQU 4 if !minor! GEQ 2 set use_extension=true
+)
+
+if "!use_extension!" == "true" (
+    if exist "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" (set blender-addon=true) else (set blender-addon=false)
+) else (
+    if exist "%~dp0scripts\VRM_Addon_for_Blender-release.zip" (set blender-addon=true) else (set blender-addon=false)
+)
 
 echo.
 echo ===Enviroment Checker===
@@ -23,12 +45,24 @@ echo BlenderVersion: %version%
 echo BlenderInstallLocation: %blender%
 echo CurlResult: %curlresult%
 echo WindowsVersion: %windowsversion%
-echo BlenderAddonInstalled: %blender-addon%
+echo BlenderAddonInstalled: !blender-addon!
+echo UseExtension: !use_extension!
 
 timeout 3
 
-echo "VRMアドオンの最新版を取得中…"
-curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-release.zip" https://github.com/saturday06/VRM_Addon_for_Blender/raw/release-archive/VRM_Addon_for_Blender-release.zip
+if "!use_extension!" == "true" (
+    echo "Extension版VRMアドオンの最新版を取得中…"
+    for /f "usebackq delims=" %%A in (`powershell -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM-Addon-for-Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
+    if defined extension_url (
+        curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
+    ) else (
+        echo "Extension版のダウンロードURLの取得に失敗しました"
+        goto error-addon
+    )
+) else (
+    echo "VRMアドオンの最新版を取得中…"
+    curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-release.zip" https://github.com/saturday06/VRM_Addon_for_Blender/raw/release-archive/VRM_Addon_for_Blender-release.zip
+)
 
 if "%blender%" == "" (
 echo "Blenderが検出できませんでした。インストーラをダウンロードし、インストールします"
@@ -40,6 +74,13 @@ set blender='%blender%'
 
 for /f "usebackq delims=" %%A in (`powershell -command "Join-Path %blender% blender.exe"`) do set blender=%%A
 set blender="%blender%"
+
+rem Extension mode: pre-install extension via Blender CLI
+if "!use_extension!" == "true" (
+    echo "VRM Extensionをインストール中…"
+    %blender% --command extension install-file "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" -r user_default -e
+)
+
 :cycle
 
 set VRM=%1
@@ -50,7 +91,11 @@ echo ===Convert Files Checker===
 echo BLENDER = %BLENDER%
 echo VRM = %VRM%
 echo OUTPUT = %OUTPUT%
-echo ADDONFILE = "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
+if "!use_extension!" == "true" (
+    echo ADDONFILE = Extension mode
+) else (
+    echo ADDONFILE = "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
+)
 echo.
 echo.
 
@@ -58,15 +103,18 @@ IF NOT DEFINED BLENDER goto error-blender
 IF NOT EXIST %BLENDER% goto error-blender
 IF NOT DEFINED VRM goto error-drop
 IF NOT EXIST %VRM% goto error-drop
-IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-release.zip" goto error-addon
+if "!use_extension!" == "true" (
+    IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" goto error-addon
+) else (
+    IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-release.zip" goto error-addon
+)
 
 echo ===Convert Start===
-%BLENDER% "%~dp0scripts\empty.blend"^
- --python "%~dp0scripts\vrmconv.py"^
- --background^
- -- --input %VRM%^
- --output %OUTPUT%^
- --addonfile "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
+if "!use_extension!" == "true" (
+    %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" --background -- --input %VRM% --output %OUTPUT%
+) else (
+    %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" --background -- --input %VRM% --output %OUTPUT% --addonfile "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
+)
 echo ===Convert End===
 echo.
 echo.

--- a/_convert.bat
+++ b/_convert.bat
@@ -9,7 +9,10 @@ for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProp
 for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%
 
-if defined BLENDER_LOCATION_OVERRIDE (set "blender=%BLENDER_LOCATION_OVERRIDE%")
+if defined BLENDER_LOCATION_OVERRIDE (
+    set "blender=%BLENDER_LOCATION_OVERRIDE%"
+    set "version="
+)
 
 rem Fallback: レジストリからバージョンを取得できない場合(Steam版等)、blender.exeから直接取得
 if "%version%" == "" if defined blender (
@@ -22,22 +25,24 @@ if "%version%" == "" if defined blender (
 for /f "usebackq delims=" %%A in (`curl --version`) do set curlresult=%%A
 for /f "usebackq delims=" %%A in (`ver`) do set windowsversion=%%A
 
-rem Blender 4.2以上ではExtensionシステムを使用
+rem Blender 4.2以上のみ対応し、Extensionシステムを使用
 set use_extension=false
+set supported_blender=false
 for /f "tokens=1,2 delims=." %%a in ("%version%") do (
     set major=%%a
     set minor=%%b
 )
 if defined major (
-    if !major! GEQ 5 set use_extension=true
-    if !major! EQU 4 if defined minor if !minor! GEQ 2 set use_extension=true
+    if !major! GEQ 5 (
+        set use_extension=true
+        set supported_blender=true
+    )
+    if !major! EQU 4 if defined minor if !minor! GEQ 2 (
+        set use_extension=true
+        set supported_blender=true
+    )
 )
-
-if "!use_extension!" == "true" (
-    if exist "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" (set blender-addon=true) else (set blender-addon=false)
-) else (
-    if exist "%~dp0scripts\VRM_Addon_for_Blender-release.zip" (set blender-addon=true) else (set blender-addon=false)
-)
+if exist "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" (set blender-addon=true) else (set blender-addon=false)
 
 echo.
 echo ===Enviroment Checker===
@@ -50,25 +55,20 @@ echo UseExtension: !use_extension!
 
 timeout 3
 
-if "!use_extension!" == "true" (
-    echo "Extension版VRMアドオンの最新版を取得中…"
-    for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM_Addon_for_Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
-    if defined extension_url (
-        curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
-    ) else (
-        echo "Extension版のダウンロードURLの取得に失敗しました"
-        goto error-addon
-    )
-) else (
-    echo "VRMアドオンの最新版を取得中…"
-    curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-release.zip" https://github.com/saturday06/VRM_Addon_for_Blender/raw/release-archive/VRM_Addon_for_Blender-release.zip
-)
-
 if "%blender%" == "" (
-echo "Blenderが検出できませんでした。インストーラをダウンロードし、インストールします"
-curl -L -o "%~dp0Blender.msi" https://mirrors.aliyun.com/blender/release/Blender3.6/blender-3.6.4-windows-x64.msi
-Blender.msi
-goto first
+    echo "Blenderが検出できませんでした。インストールしているか、BLENDER_LOCATION_OVERRIDE環境変数で場所を指定しているか確認してください。"
+    echo "Blender公式サイト: https://www.blender.org/download/"
+    goto error-blender
+)
+if "!supported_blender!" == "false" goto error-blender-version
+
+echo "Extension版VRMアドオンの最新版を取得中…"
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM_Addon_for_Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
+if defined extension_url (
+    curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
+) else (
+    echo "Extension版のダウンロードURLの取得に失敗しました"
+    goto error-addon
 )
 set blender='%blender%'
 
@@ -97,11 +97,7 @@ echo ===Convert Files Checker===
 echo BLENDER = %BLENDER%
 echo VRM = %VRM%
 echo OUTPUT = %OUTPUT%
-if "!use_extension!" == "true" (
-    echo ADDONFILE = Extension mode
-) else (
-    echo ADDONFILE = "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
-)
+echo ADDONFILE = Extension mode
 echo.
 echo.
 
@@ -109,18 +105,10 @@ IF NOT DEFINED BLENDER goto error-blender
 IF NOT EXIST %BLENDER% goto error-blender
 IF NOT DEFINED VRM goto error-drop
 IF NOT EXIST %VRM% goto error-drop
-if "!use_extension!" == "true" (
-    IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" goto error-addon
-) else (
-    IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-release.zip" goto error-addon
-)
+IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" goto error-addon
 
 echo ===Convert Start===
-if "!use_extension!" == "true" (
-    %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" --background -- --input %VRM% --output %OUTPUT%
-) else (
-    %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" --background -- --input %VRM% --output %OUTPUT% --addonfile "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
-)
+%BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" --background -- --input %VRM% --output %OUTPUT%
 echo ===Convert End===
 echo.
 echo.
@@ -132,7 +120,7 @@ if not exist %OUTPUT% (
     echo "このパネルを上に戻っていただき、ライセンス上問題があるファイルかどうか確認してください"
     echo "(問題のあるファイルの場合、その旨記載があります)"
     echo.
-    
+
     set /p Select="ライセンス上問題のあるファイルでしたか？: [Y]はい / [N]いいえ:"
 
     echo Select is !Select!
@@ -205,7 +193,15 @@ goto end
 echo "Blenderを標準のインストール位置から変更しているか、そもそもインストールしていない可能性があります"
 echo "標準のインストール位置から変更している場合はblender.exeまでのパスが通っているか確認してください(フォルダ名まで検索した後は手動で処理しています)"
 echo "Blenderのインストール場所を手動で指定する場合は BLENDER_LOCATION_OVERRIDE 環境変数にblender.exeが入っているディレクトリを指定してください"
-echo "インストールしていない場合はBlender3.4以上をインストールお願いします"
+echo "インストールしていない場合はBlender4.2以上をインストールお願いします"
+echo "何かキーをクリックすると終了します"
+pause
+goto end
+
+:error-blender-version
+echo "このツールはBlender 4.2以上でのみ動作します"
+echo "検出されたBlenderバージョン: %version%"
+echo "Blender 4.2 LTS以降をインストールしてください"
 echo "何かキーをクリックすると終了します"
 pause
 goto end
@@ -220,7 +216,7 @@ goto end
 echo "アドオンのダウンロードに失敗しています"
 echo "パソコンの設定を確認の上、再度実行してください(失効証明書管理サーバが正常に機能していない際にこの問題が起きることがあります)"
 echo "もしくは、右のリンクから手動でダウンロードし、このbatがある階層にD&Dしてください: "
-echo "https://github.com/saturday06/VRM_Addon_for_Blender/raw/release-archive/VRM_Addon_for_Blender-release.zip"
+echo "https://github.com/saturday06/VRM_Addon_for_Blender/releases/latest"
 echo "何かキーをクリックすると終了します"
 pause
 :end

--- a/_convert_manual.bat
+++ b/_convert_manual.bat
@@ -8,7 +8,7 @@ for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProp
 for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%
 
-if defined BLENDER_LOCATION_OVERRIDE (set blender=%BLENDER_LOCATION_OVERRIDE%)
+if defined BLENDER_LOCATION_OVERRIDE (set "blender=%BLENDER_LOCATION_OVERRIDE%")
 
 rem Fallback: レジストリからバージョンを取得できない場合(Steam版等)、blender.exeから直接取得
 if "%version%" == "" if defined blender (

--- a/_convert_manual.bat
+++ b/_convert_manual.bat
@@ -1,6 +1,6 @@
 @echo off
 chcp 65001
-setlocal
+setlocal enabledelayedexpansion
 
 set BLENDER_USER_CONFIG=%~dp0%\scripts\VRMConvert
 set BLENDER_USER_SCRIPTS=%~dp0%\scripts\VRMConvert
@@ -10,25 +10,59 @@ set blender=%blender:"=%
 
 if defined BLENDER_LOCATION_OVERRIDE (set blender=%BLENDER_LOCATION_OVERRIDE%)
 
+rem Fallback: レジストリからバージョンを取得できない場合(Steam版等)、blender.exeから直接取得
+if "%version%" == "" if defined blender (
+    echo "レジストリからBlenderバージョンを検出できませんでした。blender.exeから直接取得します…"
+    for /f "tokens=2 delims= " %%A in ('"%blender%\blender.exe" --version 2^>nul') do (
+        if not defined version set version=%%A
+    )
+)
+
 for /f "usebackq delims=" %%A in (`curl --version`) do set curlresult=%%A
 for /f "usebackq delims=" %%A in (`ver`) do set windowsversion=%%A
 
-if exist "%~dp0scripts\VRM_Addon_for_Blender-release.zip" set blender-addon=true
-if not exist "%~dp0scripts\VRM_Addon_for_Blender-release.zip" set blender-addon=false
+rem Blender 4.2以上ではExtensionシステムを使用
+set use_extension=false
+for /f "tokens=1,2 delims=." %%a in ("%version%") do (
+    set major=%%a
+    set minor=%%b
+)
+if defined major (
+    if !major! GEQ 5 set use_extension=true
+    if !major! EQU 4 if !minor! GEQ 2 set use_extension=true
+)
+
+if "!use_extension!" == "true" (
+    if exist "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" (set blender-addon=true) else (set blender-addon=false)
+) else (
+    if exist "%~dp0scripts\VRM_Addon_for_Blender-release.zip" (set blender-addon=true) else (set blender-addon=false)
+)
 
 echo ===Enviroment Checker. if alert to send from Dev, send it!===
 echo BlenderVersion: %version%
 echo BlenderInstallLocation: %blender%
 echo CurlResult: %curlresult%
 echo WindowsVersion: %windowsversion%
-echo BlenderAddonInstalled: %blender-addon%
+echo BlenderAddonInstalled: !blender-addon!
+echo UseExtension: !use_extension!
 echo ===Enviroment Checker. if alert to send from Dev, send it!===
 
 timeout 3
 
 
-echo "VRMアドオンの最新版を取得中…"
-curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-release.zip" https://github.com/saturday06/VRM_Addon_for_Blender/raw/release-archive/VRM_Addon_for_Blender-release.zip
+if "!use_extension!" == "true" (
+    echo "Extension版VRMアドオンの最新版を取得中…"
+    for /f "usebackq delims=" %%A in (`powershell -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM-Addon-for-Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
+    if defined extension_url (
+        curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
+    ) else (
+        echo "Extension版のダウンロードURLの取得に失敗しました"
+        goto error-addon
+    )
+) else (
+    echo "VRMアドオンの最新版を取得中…"
+    curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-release.zip" https://github.com/saturday06/VRM_Addon_for_Blender/raw/release-archive/VRM_Addon_for_Blender-release.zip
+)
 
 if "%blender%" == "" (
 echo "Blenderが検出できませんでした。インストーラをダウンロードし、インストールします"
@@ -40,25 +74,40 @@ set blender='%blender%'
 
 for /f "usebackq delims=" %%A in (`powershell -command "Join-Path %blender% blender.exe"`) do set blender=%%A
 set blender="%blender%"
+
+rem Extension mode: pre-install extension via Blender CLI
+if "!use_extension!" == "true" (
+    echo "VRM Extensionをインストール中…"
+    %blender% --command extension install-file "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" -r user_default -e
+)
+
 set VRM=%1
 set OUTPUT="%~1-converted.glb"
 
 echo BLENDER = %BLENDER%
 echo VRM = %VRM%
 echo OUTPUT = %OUTPUT%
-echo ADDONFILE = "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
+if "!use_extension!" == "true" (
+    echo ADDONFILE = Extension mode
+) else (
+    echo ADDONFILE = "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
+)
 
 IF NOT DEFINED BLENDER goto error-blender
 IF NOT EXIST %BLENDER% goto error-blender
 IF NOT DEFINED VRM goto error-drop
 IF NOT EXIST %VRM% goto error-drop
-IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-release.zip" goto error-addon
+if "!use_extension!" == "true" (
+    IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" goto error-addon
+) else (
+    IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-release.zip" goto error-addon
+)
 
-%BLENDER% "%~dp0scripts\empty.blend"^
- --python "%~dp0scripts\vrmconv.py"^
- -- --input %VRM%^
- --output %OUTPUT%^
- --addonfile "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
+if "!use_extension!" == "true" (
+    %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" -- --input %VRM% --output %OUTPUT%
+) else (
+    %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" -- --input %VRM% --output %OUTPUT% --addonfile "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
+)
 rem --fbx True
 
 :error-blender

--- a/_convert_manual.bat
+++ b/_convert_manual.bat
@@ -8,7 +8,10 @@ for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProp
 for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%
 
-if defined BLENDER_LOCATION_OVERRIDE (set "blender=%BLENDER_LOCATION_OVERRIDE%")
+if defined BLENDER_LOCATION_OVERRIDE (
+    set "blender=%BLENDER_LOCATION_OVERRIDE%"
+    set "version="
+)
 
 rem Fallback: レジストリからバージョンを取得できない場合(Steam版等)、blender.exeから直接取得
 if "%version%" == "" if defined blender (
@@ -21,22 +24,24 @@ if "%version%" == "" if defined blender (
 for /f "usebackq delims=" %%A in (`curl --version`) do set curlresult=%%A
 for /f "usebackq delims=" %%A in (`ver`) do set windowsversion=%%A
 
-rem Blender 4.2以上ではExtensionシステムを使用
+rem Blender 4.2以上のみ対応し、Extensionシステムを使用
 set use_extension=false
+set supported_blender=false
 for /f "tokens=1,2 delims=." %%a in ("%version%") do (
     set major=%%a
     set minor=%%b
 )
 if defined major (
-    if !major! GEQ 5 set use_extension=true
-    if !major! EQU 4 if defined minor if !minor! GEQ 2 set use_extension=true
+    if !major! GEQ 5 (
+        set use_extension=true
+        set supported_blender=true
+    )
+    if !major! EQU 4 if defined minor if !minor! GEQ 2 (
+        set use_extension=true
+        set supported_blender=true
+    )
 )
-
-if "!use_extension!" == "true" (
-    if exist "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" (set blender-addon=true) else (set blender-addon=false)
-) else (
-    if exist "%~dp0scripts\VRM_Addon_for_Blender-release.zip" (set blender-addon=true) else (set blender-addon=false)
-)
+if exist "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" (set blender-addon=true) else (set blender-addon=false)
 
 echo ===Enviroment Checker. if alert to send from Dev, send it!===
 echo BlenderVersion: %version%
@@ -50,25 +55,20 @@ echo ===Enviroment Checker. if alert to send from Dev, send it!===
 timeout 3
 
 
-if "!use_extension!" == "true" (
-    echo "Extension版VRMアドオンの最新版を取得中…"
-    for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM_Addon_for_Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
-    if defined extension_url (
-        curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
-    ) else (
-        echo "Extension版のダウンロードURLの取得に失敗しました"
-        goto error-addon
-    )
-) else (
-    echo "VRMアドオンの最新版を取得中…"
-    curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-release.zip" https://github.com/saturday06/VRM_Addon_for_Blender/raw/release-archive/VRM_Addon_for_Blender-release.zip
-)
-
 if "%blender%" == "" (
-echo "Blenderが検出できませんでした。インストーラをダウンロードし、インストールします"
-curl -L -o "%~dp0Blender.msi" https://mirrors.aliyun.com/blender/release/Blender3.6/blender-3.6.4-windows-x64.msi
-Blender.msi
-goto first
+    echo "Blenderが検出できませんでした。インストールしているか、BLENDER_LOCATION_OVERRIDE環境変数で場所を指定しているか確認してください。"
+    echo "Blender公式サイト: https://www.blender.org/download/"
+    goto error-blender
+)
+if "!supported_blender!" == "false" goto error-blender-version
+
+echo "Extension版VRMアドオンの最新版を取得中…"
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM_Addon_for_Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
+if defined extension_url (
+    curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
+) else (
+    echo "Extension版のダウンロードURLの取得に失敗しました"
+    goto error-addon
 )
 set blender='%blender%'
 
@@ -92,27 +92,15 @@ set OUTPUT="%VRM_PATH%-converted.glb"
 echo BLENDER = %BLENDER%
 echo VRM = %VRM%
 echo OUTPUT = %OUTPUT%
-if "!use_extension!" == "true" (
-    echo ADDONFILE = Extension mode
-) else (
-    echo ADDONFILE = "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
-)
+echo ADDONFILE = Extension mode
 
 IF NOT DEFINED BLENDER goto error-blender
 IF NOT EXIST %BLENDER% goto error-blender
 IF NOT DEFINED VRM goto error-drop
 IF NOT EXIST %VRM% goto error-drop
-if "!use_extension!" == "true" (
-    IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" goto error-addon
-) else (
-    IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-release.zip" goto error-addon
-)
+IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" goto error-addon
 
-if "!use_extension!" == "true" (
-    %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" -- --input %VRM% --output %OUTPUT%
-) else (
-    %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" -- --input %VRM% --output %OUTPUT% --addonfile "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
-)
+%BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" -- --input %VRM% --output %OUTPUT%
 rem --fbx True
 goto end
 
@@ -120,7 +108,15 @@ goto end
 echo "Blenderを標準のインストール位置から変更しているか、そもそもインストールしていない可能性があります"
 echo "標準のインストール位置から変更している場合はblender.exeまでのパスが通っているか確認してください(フォルダ名まで検索した後は手動で処理しています)"
 echo "Blenderのインストール場所を手動で指定する場合は BLENDER_LOCATION_OVERRIDE 環境変数にblender.exeが入っているディレクトリを指定してください"
-echo "インストールしていない場合はBlender3.4以上をインストールお願いします"
+echo "インストールしていない場合はBlender4.2以上をインストールお願いします"
+echo "何かキーをクリックすると終了します"
+pause
+goto end
+
+:error-blender-version
+echo "このツールはBlender 4.2以上でのみ動作します"
+echo "検出されたBlenderバージョン: %version%"
+echo "Blender 4.2 LTS以降をインストールしてください"
 echo "何かキーをクリックすると終了します"
 pause
 goto end
@@ -135,7 +131,7 @@ goto end
 echo "アドオンのダウンロードに失敗しています"
 echo "パソコンの設定を確認の上、再度実行してください(失効証明書管理サーバが正常に機能していない際にこの問題が起きることがあります)"
 echo "もしくは、右のリンクから手動でダウンロードし、このbatがある階層にD&Dしてください: "
-echo "https://github.com/saturday06/VRM_Addon_for_Blender/raw/release-archive/VRM_Addon_for_Blender-release.zip"
+echo "https://github.com/saturday06/VRM_Addon_for_Blender/releases/latest"
 echo "何かキーをクリックすると終了します"
 pause
 :end

--- a/_convert_manual.bat
+++ b/_convert_manual.bat
@@ -4,8 +4,8 @@ setlocal enabledelayedexpansion
 
 set BLENDER_USER_CONFIG=%~dp0%\scripts\VRMConvert
 set BLENDER_USER_SCRIPTS=%~dp0%\scripts\VRMConvert
-for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).DisplayVersion"`) do set version=%%A
-for /f "usebackq delims=" %%A in (`powershell -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).DisplayVersion"`) do set version=%%A
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "(Get-ItemProperty HKLM:\Software\\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName,DisplayVersion,InstallLocation | Where-Object {$_.DisplayName -eq \"Blender\"} | Sort -Property DisplayVersion | Select-Object -Last 1 ).InstallLocation"`) do set blender=%%A
 set blender=%blender:"=%
 
 if defined BLENDER_LOCATION_OVERRIDE (set blender=%BLENDER_LOCATION_OVERRIDE%)
@@ -52,7 +52,7 @@ timeout 3
 
 if "!use_extension!" == "true" (
     echo "Extension版VRMアドオンの最新版を取得中…"
-    for /f "usebackq delims=" %%A in (`powershell -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM-Addon-for-Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
+    for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM-Addon-for-Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
     if defined extension_url (
         curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
     ) else (
@@ -72,7 +72,7 @@ goto first
 )
 set blender='%blender%'
 
-for /f "usebackq delims=" %%A in (`powershell -command "Join-Path %blender% blender.exe"`) do set blender=%%A
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "Join-Path %blender% blender.exe"`) do set blender=%%A
 set blender="%blender%"
 
 rem Extension mode: pre-install extension via Blender CLI
@@ -82,7 +82,12 @@ if "!use_extension!" == "true" (
 )
 
 set VRM=%1
-set OUTPUT="%~1-converted.glb"
+set VRM_PATH=%~1
+if "%VRM_PATH:~0,2%" == "~/" set VRM_PATH=%USERPROFILE%\%VRM_PATH:~2%
+if "%VRM_PATH:~0,2%" == "~\" set VRM_PATH=%USERPROFILE%\%VRM_PATH:~2%
+set VRM_PATH=%VRM_PATH:/=\%
+if not "%VRM_PATH%" == "" set VRM="%VRM_PATH%"
+set OUTPUT="%VRM_PATH%-converted.glb"
 
 echo BLENDER = %BLENDER%
 echo VRM = %VRM%
@@ -109,6 +114,7 @@ if "!use_extension!" == "true" (
     %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" -- --input %VRM% --output %OUTPUT% --addonfile "%~dp0scripts\VRM_Addon_for_Blender-release.zip"
 )
 rem --fbx True
+goto end
 
 :error-blender
 echo "Blenderを標準のインストール位置から変更しているか、そもそもインストールしていない可能性があります"

--- a/_convert_manual.bat
+++ b/_convert_manual.bat
@@ -25,7 +25,6 @@ for /f "usebackq delims=" %%A in (`curl --version`) do set curlresult=%%A
 for /f "usebackq delims=" %%A in (`ver`) do set windowsversion=%%A
 
 rem Blender 4.2以上のみ対応し、Extensionシステムを使用
-set use_extension=false
 set supported_blender=false
 for /f "tokens=1,2 delims=." %%a in ("%version%") do (
     set major=%%a
@@ -33,33 +32,22 @@ for /f "tokens=1,2 delims=." %%a in ("%version%") do (
 )
 if defined major (
     if !major! GEQ 5 (
-        set use_extension=true
         set supported_blender=true
     )
     if !major! EQU 4 if defined minor if !minor! GEQ 2 (
-        set use_extension=true
         set supported_blender=true
     )
 )
-if exist "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" (set blender-addon=true) else (set blender-addon=false)
-
-echo ===Enviroment Checker. if alert to send from Dev, send it!===
+echo.
+echo ===Enviroment Checker===
 echo BlenderVersion: %version%
 echo BlenderInstallLocation: %blender%
 echo CurlResult: %curlresult%
 echo WindowsVersion: %windowsversion%
-echo BlenderAddonInstalled: !blender-addon!
-echo UseExtension: !use_extension!
-echo ===Enviroment Checker. if alert to send from Dev, send it!===
 
 timeout 3
 
-
-if "%blender%" == "" (
-    echo "Blenderが検出できませんでした。インストールしているか、BLENDER_LOCATION_OVERRIDE環境変数で場所を指定しているか確認してください。"
-    echo "Blender公式サイト: https://www.blender.org/download/"
-    goto error-blender
-)
+if "%blender%" == "" goto error-blender
 if "!supported_blender!" == "false" goto error-blender-version
 
 echo "Extension版VRMアドオンの最新版を取得中…"
@@ -76,10 +64,8 @@ for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "Join-Path %bl
 set blender="%blender%"
 
 rem Extension mode: pre-install extension via Blender CLI
-if "!use_extension!" == "true" (
-    echo "VRM Extensionをインストール中…"
-    %blender% --command extension install-file "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" -r user_default -e
-)
+echo "VRM Extensionをインストール中…"
+%blender% --command extension install-file "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" -r user_default -e
 
 set VRM=%1
 set VRM_PATH=%~1
@@ -89,10 +75,14 @@ set VRM_PATH=%VRM_PATH:/=\%
 if not "%VRM_PATH%" == "" set VRM="%VRM_PATH%"
 set OUTPUT="%VRM_PATH%-converted.glb"
 
+echo.
+echo ===Convert Files Checker===
 echo BLENDER = %BLENDER%
 echo VRM = %VRM%
 echo OUTPUT = %OUTPUT%
-echo ADDONFILE = Extension mode
+echo EXTENSIONFILE = "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip"
+echo.
+echo.
 
 IF NOT DEFINED BLENDER goto error-blender
 IF NOT EXIST %BLENDER% goto error-blender
@@ -100,8 +90,11 @@ IF NOT DEFINED VRM goto error-drop
 IF NOT EXIST %VRM% goto error-drop
 IF NOT EXIST "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" goto error-addon
 
+echo ===Convert Start===
 %BLENDER% "%~dp0scripts\empty.blend" --python "%~dp0scripts\vrmconv.py" -- --input %VRM% --output %OUTPUT%
-rem --fbx True
+echo ===Convert End===
+echo.
+echo.
 goto end
 
 :error-blender
@@ -109,6 +102,7 @@ echo "Blenderを標準のインストール位置から変更しているか、�
 echo "標準のインストール位置から変更している場合はblender.exeまでのパスが通っているか確認してください(フォルダ名まで検索した後は手動で処理しています)"
 echo "Blenderのインストール場所を手動で指定する場合は BLENDER_LOCATION_OVERRIDE 環境変数にblender.exeが入っているディレクトリを指定してください"
 echo "インストールしていない場合はBlender4.2以上をインストールお願いします"
+echo "Blender公式サイト: https://www.blender.org/download/"
 echo "何かキーをクリックすると終了します"
 pause
 goto end

--- a/_convert_manual.bat
+++ b/_convert_manual.bat
@@ -29,7 +29,7 @@ for /f "tokens=1,2 delims=." %%a in ("%version%") do (
 )
 if defined major (
     if !major! GEQ 5 set use_extension=true
-    if !major! EQU 4 if !minor! GEQ 2 set use_extension=true
+    if !major! EQU 4 if defined minor if !minor! GEQ 2 set use_extension=true
 )
 
 if "!use_extension!" == "true" (
@@ -52,7 +52,7 @@ timeout 3
 
 if "!use_extension!" == "true" (
     echo "Extension版VRMアドオンの最新版を取得中…"
-    for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM-Addon-for-Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
+    for /f "usebackq delims=" %%A in (`powershell -NoProfile -command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/saturday06/VRM_Addon_for_Blender/releases/latest'; ($r.assets | Where-Object { $_.name -like '*Extension*' } | Select-Object -First 1).browser_download_url } catch { Write-Output '' }"`) do set extension_url=%%A
     if defined extension_url (
         curl -L -o "%~dp0scripts\VRM_Addon_for_Blender-Extension-release.zip" "!extension_url!"
     ) else (

--- a/scripts/vrmconv.py
+++ b/scripts/vrmconv.py
@@ -127,20 +127,12 @@ if '__main__' == __name__:
     parser.add_argument('--input', required=True)
     parser.add_argument('--output', required=True)
     parser.add_argument('--fbx', required=False)
-    parser.add_argument('--addonfile', required=False)
     
     args = parser.parse_args(sys.argv[sys.argv.index('--') + 1:])
     
     input = args.input
     output = args.output
     fbx = args.fbx
-    addonfile = args.addonfile
-
-    if addonfile:
-        # Legacy addon installation (Blender < 4.2)
-        bpy.ops.preferences.addon_install(filepath=addonfile, overwrite = True)
-        bpy.ops.preferences.addon_enable(module="VRM_Addon_for_Blender-release")
-    # else: Extension mode (Blender 4.2+) - extension is pre-installed via CLI
 
     bpy.ops.import_scene.vrm(filepath=input, extract_textures_into_folder=True)
 

--- a/scripts/vrmconv.py
+++ b/scripts/vrmconv.py
@@ -136,8 +136,12 @@ if '__main__' == __name__:
     fbx = args.fbx
     addonfile = args.addonfile
 
-    bpy.ops.preferences.addon_install(filepath=addonfile, overwrite = True)
-    bpy.ops.preferences.addon_enable(module="VRM_Addon_for_Blender-release")
+    if addonfile:
+        # Legacy addon installation (Blender < 4.2)
+        bpy.ops.preferences.addon_install(filepath=addonfile, overwrite = True)
+        bpy.ops.preferences.addon_enable(module="VRM_Addon_for_Blender-release")
+    # else: Extension mode (Blender 4.2+) - extension is pre-installed via CLI
+
     bpy.ops.import_scene.vrm(filepath=input, extract_textures_into_folder=True)
 
     bpy.context.view_layer.objects.active = bpy.data.objects[bpy.data.armatures[0].name]

--- a/scripts/vrmconv.py
+++ b/scripts/vrmconv.py
@@ -174,4 +174,8 @@ if '__main__' == __name__:
     if fbx:
         bpy.ops.export_scene.fbx(filepath=output, embed_textures=True, path_mode='COPY', object_types={'ARMATURE', 'MESH'}, global_scale=0.01)
     else:
-        bpy.ops.export_scene.gltf(filepath=output)
+        bpy.ops.export_scene.gltf(
+            filepath=output,
+            export_try_sparse_sk=False,
+            export_try_omit_sparse_sk=False,
+        )


### PR DESCRIPTION
## Summary

- Run PowerShell calls with `-NoProfile` so unsigned user profiles do not corrupt batch `for /f` output.
- Normalize `~/...` and slash-separated VRM paths before passing them to Blender.
- Apply the same path and PowerShell fixes to `_convert_manual.bat`, and stop it from falling through to the Blender error block after a successful conversion.
- Ignore downloaded VRM Add-on ZIP files under `scripts/`.

## Validation

- Ran `_convert_manual.bat "~\Downloads\vrm\AvatarSample_A.v0.vrm"` with `BLENDER_VRM_AUTOMATIC_LICENSE_CONFIRMATION=true`; it generated `C:\Users\yoshi\Downloads\vrm\AvatarSample_A.v0.vrm-converted.glb`.
- Ran `git diff --check`.